### PR TITLE
EC2 Name Generator

### DIFF
--- a/EC2 Random Name Generator.ipynb
+++ b/EC2 Random Name Generator.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Several departments share an AWS environment. You need to ensure that the EC2s are properly named and are unique so team members can easily tell who the EC2 instances belong to. Use Python to create your unique EC2 names that the users can then attach to the instances. The Python Script should:\n",
+    "#1. All the user to input how many EC2 instances they want names for and output the same amount of unique names.\n",
+    "#2. Allow the user to input the name of their department that is used in the unique name.\n",
+    "#3. Generate random characters and numbers that will be included in the unique name.\n",
+    "#4. Push your code to GitHub and include the link in your LinkedIn write up.\n",
+    "\n",
+    "#ADVANCED\n",
+    "#The only departments that should use this Name Generator are the Marketing, Accounting, and FinOps Departments. List these departments as options and if a user puts another department, print a message that they should not use this Name Generator. Be sure to account for incorrect upper or lowercase letters in the correct department. Example: a user inputs accounting vs Accounting.\n",
+    "\n",
+    "#COMPLEX\n",
+    "#Turn the above into a Function and execute the Function to verify it works.\n",
+    "\n",
+    "import random\n",
+    "\n",
+    "department_name = str(input('What department is this instance or instances for?'))\n",
+    "amount_of_instances = int(input('How many instances do you want to name?'))\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is a scripts that generate UID's for assests like EC2 instances. It asks the user what department they belong to and how many instances they want to launch. When the conditions are satisfied it provides them with UID's for the instances they specified based on the department name. It will not generate UID's for instances that arent specified. Let me know what you think.